### PR TITLE
Fix columns width when wrapping text

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ your node.js scripts.
 - Text alignment (left, right, center)
 - Padding (left, right)
 - Easy-to-use API
+- Text wrapping
+- Minimum column width
 
 ## Installation
 
@@ -163,6 +165,13 @@ console.log(table.toString());
 ```
 ![Screenshot](/img/cli-colors-example.png)
 
+### Text wrapping
+If table's width is bigger than terminal width, the text in each column will be wrapped and show on multiple lines. 
+Each column width will be recalculated in order to match the relation between them. In this case the ```min_column_width```option is respected.
+In case column's required width is below ```min_column_width```, it will be saved and shown with its required size.
+In case column's required width is above ```min_column_width```, it will be recalculated based on the required and available space. If the calculated value is below ```min_column_width```, the column's width will be ```min_column_width```. In case the value is above ```min_column_width```, it will be used. Calculations are dynamic based on the available space.
+
+> NOTE: Default value of ```min_column_width``` is 15.
 
 ## Running tests
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,6 @@
 
 var colors = require('colors/safe')
   , utils = require('./utils')
-  , beautify = require('js-beautify').html
   , repeat = utils.repeat
   , truncate = utils.truncate
   , pad = utils.pad
@@ -77,7 +76,7 @@ Table.prototype.__defineGetter__('width', function (){
  * @api public
  */
 
-Table.prototype.render
+Table.prototype.render = 
 Table.prototype.toString = function (){
   var ret = ''
     , options = this.options
@@ -92,30 +91,30 @@ Table.prototype.toString = function (){
   // The minimum width of a column when terminal width is above table's required one.
   // NOTE: Columns which have required width below min_column_width will be renedered with their required width.  
   var min_column_width = options.min_column_width || 15 ;
-    if (!head.length && !this.length) return '';
+  if (!head.length && !this.length) return '';
 
-    if (!colWidths.length){
-      var all_rows = this.slice(0);
-      if (head.length) { all_rows = all_rows.concat([head]) };
+  if (!colWidths.length){
+    var all_rows = this.slice(0);
+    if (head.length) { all_rows = all_rows.concat([head]) };
 
-      all_rows.forEach(function(cells){
-        // horizontal (arrays)
-        if (typeof cells === 'object' && cells.length) {
-          extractColumnWidths(cells);
-        // vertical (objects)
+    all_rows.forEach(function(cells){
+      // horizontal (arrays)
+      if (typeof cells === 'object' && cells.length) {
+        extractColumnWidths(cells);
+      // vertical (objects)
+      } else {
+        var header_cell = Object.keys(cells)[0]
+          , value_cell = cells[header_cell];
+
+        colWidths[0] = Math.max(colWidths[0] || 0, get_width(header_cell) || 0);
+
+        // cross (objects w/ array values)
+        if (typeof value_cell === 'object' && value_cell.length) {
+          extractColumnWidths(value_cell, 1);
         } else {
-          var header_cell = Object.keys(cells)[0]
-            , value_cell = cells[header_cell];
-
-          colWidths[0] = Math.max(colWidths[0] || 0, get_width(header_cell) || 0);
-
-          // cross (objects w/ array values)
-          if (typeof value_cell === 'object' && value_cell.length) {
-            extractColumnWidths(value_cell, 1);
-          } else {
-            colWidths[1] = Math.max(colWidths[1] || 0, get_width(value_cell) || 0);
-          }
+          colWidths[1] = Math.max(colWidths[1] || 0, get_width(value_cell) || 0);
         }
+      }
     });
 
     calc_required_width = function(){
@@ -129,8 +128,7 @@ Table.prototype.toString = function (){
 
     //Make sure total column widths don't exceed terminal width
     required_width = calc_required_width();
-    
-    if(terminal_width <= required_width){
+    if(terminal_width <= required_width) {
       var remaining_terminal_width = terminal_width - (colWidths.length * 2);
       var remaining_required_width = required_width;
       var calculated_values = [];
@@ -179,7 +177,7 @@ Table.prototype.toString = function (){
     if(calc_req_width > terminal_width) {
       console.warn("Calculated width "+ calc_req_width +" is above terminal width: " + terminal_width + ". You can try using smaller value for min_column_width. Current value is: " + min_column_width);
     }
-
+    
     this.options.colWidths = colWidths;
   };
 
@@ -228,6 +226,110 @@ Table.prototype.toString = function (){
       ret += l + "\n";
   };
 
+  /**
+  * Checks if the passed character is a non-word symbol.
+  * @param {string} character The symbol to check.
+  */
+  function isDelimiter(character){
+    return character && character.length === 1 && character.match(/\W/);
+  }
+
+  /**
+  * Gets number of symbols which should be added to the line
+  * as it contains colorization symbols.
+  * Symbols are added until we reach wrap_line_length symbols of text
+  * which do not contain colorization.
+  * @param {string} content The whole text that will be split.
+  * @param {number} wrap_line_length Max number of symbols that we can have on the line.
+  * @return number value indicating sum of all code symbols in the text, that we'll use for current line.
+  */
+  function extendWrapLine(content, wrap_line_length) {
+    var textToTake = content.substring(0, wrap_line_length);
+    var sumOfSymbolsToAdd = 0; 
+    var mtch = [];
+    while(mtch = textToTake.match(/(\u001b\[(?:\d*;){0,5}\d*m)/)) {
+      sumOfSymbolsToAdd += mtch[1].length;
+      var indexOfMatch = textToTake.indexOf(mtch[1]);
+      textToTake = textToTake.substring(0, indexOfMatch) + textToTake.substring(indexOfMatch + mtch[1].length);
+    }
+
+    if(sumOfSymbolsToAdd === 0) {
+      return 0;
+    } else {
+      return sumOfSymbolsToAdd + extendWrapLine(textToTake, wrap_line_length + sumOfSymbolsToAdd);
+    }
+  };
+
+  /**
+  * Gets the number of "code" groups in the string.
+  * @param {string} line The text to be checked.
+  * @return Number of "code" groups.
+  */
+  function findNumberOfCodes(line) {
+    var count = 0;
+    while(mtch = line.match(/(\u001b\[(?:\d*;){0,5}\d*m)/)) {
+      count++;
+      var indexOfMatch = line.indexOf(mtch[1]);
+      line = line.substring(0, indexOfMatch) + line.substring(indexOfMatch + mtch[1].length);
+    }
+
+    return count;
+  };
+
+  /**
+  * Split text on several lines. Line's length is passed as paramater and it is the maximum number of symbols
+  * that will be used on the line.
+  * @param {string} content The text to be split.
+  * @param {number} wrap_line_length Maximum number of symbols allowed on each line.
+  * @return String splitted on several lines.
+  */
+  function beautify_string(content, wrap_line_length) {
+    // - 2 for padding, borders, etc. 
+    var wrap_value = (wrap_line_length - 2) || 250;
+    var symbolsToAdd =  extendWrapLine(content, wrap_line_length);
+    wrap_value += symbolsToAdd;
+    var current_line = content || "";
+    if (content) {
+      if (content.length > wrap_value) {
+        var remaining = "";
+        var row = _.take(content.split(""), wrap_value);
+
+        // check if the symbol after wrap_value is delimiter;
+        if (isDelimiter(content[wrap_value])) {
+          current_line = content.substring(0, wrap_value).trim();
+          remaining = content.substring(wrap_value).trim();
+        } else {
+          // find last delimiters
+          var index = _.findLastIndex(row, function(chr) {
+            return isDelimiter(chr);
+          });
+
+          if(index === -1) {
+            //no delimiter, lets just split the word
+            index = wrap_value;
+          }
+
+          current_line = content.substring(0, index).trim();
+          remaining = content.substring(index).trim();
+        }
+
+        var numberOfCodes = findNumberOfCodes(current_line);
+        if(numberOfCodes % 2 !== 0) {
+          var nextCodeMatch = current_line.match(/[\s\S]*(\u001b\[(?:\d*;){0,5}\d*m)/); //greedy
+          if(nextCodeMatch) {
+            var nextCode = nextCodeMatch[1];
+            remaining = nextCode + remaining;
+          }
+        }
+      }
+
+      return current_line + (remaining ? ('\n' + beautify_string(remaining, wrap_line_length) ): "");
+    }
+
+    // If there's no content or it's width is below wrap_line_length, return the value
+    return current_line;
+  };
+
   function generateRow (items, style) {
     var cells = []
       , max_height = 0;
@@ -248,16 +350,12 @@ Table.prototype.toString = function (){
 
     // transform array of item strings into structure of cells
     items.forEach(function (item, i) {
-
-      var contents = item.toString();
-
-      contents = beautify(contents,{
-        wrap_line_length: this.options.colWidths[i] - 7
-      });
-      contents = contents.split("\n").reduce(function (memo, l) {
-        memo.push(string(l, i));
-        return memo;
-      }, [])
+      var contents = beautify_string(item.toString(), this.options.colWidths[i])
+        .split("\n")
+        .reduce(function (memo, l) {
+          memo.push(string(l, i));
+          return memo;
+        }, [])
 
       var height = contents.length;
       if (height > max_height) { max_height = height };
@@ -308,7 +406,7 @@ Table.prototype.toString = function (){
   function string (str, index){
     var str = String(typeof str == 'object' && str.text ? str.text : str)
       , length = utils.strlen(str)
-      , width = colWidths[index]
+      , width = options.colWidths[index]
           - (style['padding-left'] || 0)
           - (style['padding-right'] || 0)
       , align = options.colAligns[index] || 'left';

--- a/lib/index.js
+++ b/lib/index.js
@@ -85,6 +85,7 @@ Table.prototype.toString = function (){
     , chars = options.chars
     , truncater = options.truncate
     , colWidths = options.colWidths || new Array(this.head.length)
+    , minColumnWidth = options.minColumnWidth || 15
     , totalWidth = 0
     , terminal_width = process.stdout.columns;
 
@@ -123,12 +124,37 @@ Table.prototype.toString = function (){
       //sum of columns, borders
       return sum + ((colWidths.length*2) - 1);
     }();
-
-    if(terminal_width < required_width){
-      var new_col_width = (terminal_width - (colWidths.length * 2) -1) / colWidths.length;
-      new_col_width = Math.floor(new_col_width);
-      colWidths = colWidths.map(function(){
-        return new_col_width;
+    
+    if(terminal_width <= required_width){
+      var remainingTerminalWidth = terminal_width - (colWidths.length * 2);
+      var remainingRequiredWidth = required_width;
+      var calculatedValues = [];
+      
+      colWidths = colWidths.map(function(col, index){
+        if(col < minColumnWidth){
+            var ceil = Math.ceil(col);
+            remainingTerminalWidth -= ceil;
+            remainingRequiredWidth -= ceil;
+            calculatedValues.forEach(function(calcValue) {
+              colWidths[calcValue.ind] = Math.floor((calcValue.originalValue/remainingRequiredWidth)*remainingTerminalWidth);
+            });
+            return ceil;
+        }
+        
+        var calculatedValue = Math.floor((col/remainingRequiredWidth)*remainingTerminalWidth);
+        if(calculatedValue >= minColumnWidth) {
+            calculatedValues.push({originalValue: col, ind: index});
+            return calculatedValue;
+        } 
+        
+        remainingTerminalWidth -= minColumnWidth;
+        remainingRequiredWidth -= col;
+        //recalculate all calculated values:
+        calculatedValues.forEach(function(calcValue) {
+            colWidths[calcValue.ind] = Math.floor((calcValue.originalValue/remainingRequiredWidth)*remainingTerminalWidth);
+        });
+        
+        return minColumnWidth;
       });
     }
 
@@ -203,11 +229,9 @@ Table.prototype.toString = function (){
 
       var contents = item.toString();
 
-      if(10 <= this.options.colWidths[i]){
-        contents = beautify(contents,{
-          wrap_line_length: this.options.colWidths[i] - 7
-        });
-      }
+      contents = beautify(contents,{
+        wrap_line_length: this.options.colWidths[i] - 7
+      });
       contents = contents.split("\n").reduce(function (memo, l) {
         memo.push(string(l, i));
         return memo;

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,10 +86,12 @@ Table.prototype.toString = function (){
     , chars = options.chars
     , truncater = options.truncate
     , colWidths = options.colWidths || new Array(this.head.length)
-    , min_column_width = options.min_column_width || 15
     , totalWidth = 0
     , terminal_width = process.stdout.columns;
-
+  
+  // The minimum width of a column when terminal width is above table's required one.
+  // NOTE: Columns which have required width below min_column_width will be renedered with their required width.  
+  var min_column_width = options.min_column_width || 15 ;
     if (!head.length && !this.length) return '';
 
     if (!colWidths.length){

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ var colors = require('colors/safe')
   , beautify = require('js-beautify').html
   , repeat = utils.repeat
   , truncate = utils.truncate
-  , pad = utils.pad;
+  , pad = utils.pad
+  , _ = require("lodash");
 
 /**
  * Table constructor
@@ -85,7 +86,7 @@ Table.prototype.toString = function (){
     , chars = options.chars
     , truncater = options.truncate
     , colWidths = options.colWidths || new Array(this.head.length)
-    , minColumnWidth = options.minColumnWidth || 15
+    , min_column_width = options.min_column_width || 15
     , totalWidth = 0
     , terminal_width = process.stdout.columns;
 
@@ -115,47 +116,66 @@ Table.prototype.toString = function (){
         }
     });
 
-    //Make sure total column widths don't exceed terminal width
-    required_width = function(){
+    calc_required_width = function(){
       sum = 0;
       colWidths.map(function(item){
           sum += item;
       });
       //sum of columns, borders
       return sum + ((colWidths.length*2) - 1);
-    }();
+    };
+
+    //Make sure total column widths don't exceed terminal width
+    required_width = calc_required_width();
     
     if(terminal_width <= required_width){
-      var remainingTerminalWidth = terminal_width - (colWidths.length * 2);
-      var remainingRequiredWidth = required_width;
-      var calculatedValues = [];
+      var remaining_terminal_width = terminal_width - (colWidths.length * 2);
+      var remaining_required_width = required_width;
+      var calculated_values = [];
       
+      var recalculate_col_widths = function() {
+        calculated_values.forEach(function(calc_value) {
+          var value = Math.floor((calc_value.original_value/remaining_required_width)*remaining_terminal_width);
+          if(value < min_column_width) {
+            // static value found - the column cannot be narrowed anymore
+            remaining_terminal_width -= min_column_width;
+            remaining_required_width -= calc_value.original_value;
+            _.pull(calculated_values, calc_value);
+            colWidths[calc_value.ind] = min_column_width;
+            recalculate_col_widths();
+          } else {
+            // dynamic value found - set columnWidth and continue recalculation
+            colWidths[calc_value.ind] =  value;
+          }
+        });
+      };
+
       colWidths = colWidths.map(function(col, index){
-        if(col < minColumnWidth){
+        if(col < min_column_width){
             var ceil = Math.ceil(col);
-            remainingTerminalWidth -= ceil;
-            remainingRequiredWidth -= ceil;
-            calculatedValues.forEach(function(calcValue) {
-              colWidths[calcValue.ind] = Math.floor((calcValue.originalValue/remainingRequiredWidth)*remainingTerminalWidth);
-            });
+            remaining_terminal_width -= ceil;
+            remaining_required_width -= ceil;
+            recalculate_col_widths();
             return ceil;
         }
         
-        var calculatedValue = Math.floor((col/remainingRequiredWidth)*remainingTerminalWidth);
-        if(calculatedValue >= minColumnWidth) {
-            calculatedValues.push({originalValue: col, ind: index});
-            return calculatedValue;
+        var calculated_value = Math.floor((col/remaining_required_width)*remaining_terminal_width);
+        if(calculated_value >= min_column_width) {
+            calculated_values.push({original_value: col, ind: index});
+            return calculated_value;
         } 
         
-        remainingTerminalWidth -= minColumnWidth;
-        remainingRequiredWidth -= col;
-        //recalculate all calculated values:
-        calculatedValues.forEach(function(calcValue) {
-            colWidths[calcValue.ind] = Math.floor((calcValue.originalValue/remainingRequiredWidth)*remainingTerminalWidth);
-        });
+        remaining_terminal_width -= min_column_width;
+        remaining_required_width -= col;
+        recalculate_col_widths();
         
-        return minColumnWidth;
+        return min_column_width;
       });
+    }
+
+    calc_req_width = calc_required_width();
+    if(calc_req_width > terminal_width) {
+      console.warn("Calculated width "+ calc_req_width +" is above terminal width: " + terminal_width + ". You can try using smaller value for min_column_width. Current value is: " + min_column_width);
     }
 
     this.options.colWidths = colWidths;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,10 +44,9 @@ exports.pad = function (str, len, pad, dir) {
  *
  * @api public
  */
-
 exports.truncate = function (str, length, chr){
   chr = chr || '…';
-  return str.length >= length ? str.substr(0, length - chr.length) + chr : str;
+  return strlen(str) >= length ? str.substr(0, length - chr.length) + chr : str;
 };
 
 /**
@@ -78,7 +77,8 @@ exports.options = options;
 //
 // see: http://en.wikipedia.org/wiki/ANSI_escape_code
 //
-exports.strlen = function(str){
+
+function strlen(str){
   var code = /\u001b\[(?:\d*;){0,5}\d*m/g;
   var stripped = ("" + str).replace(code,'');
   var split = stripped.split("\n");
@@ -87,3 +87,4 @@ exports.strlen = function(str){
     return (len > memo) ? len : memo 
   }, 0);
 }
+exports.strlen = strlen;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "dependencies": {
     "colors": "1.0.3",
-    "js-beautify": "^1.5.5",
     "lodash": "3.6.0",
     "wcwidth": "*"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "colors": "1.0.3",
     "js-beautify": "^1.5.5",
+    "lodash": "3.6.0",
     "wcwidth": "*"
   },
   

--- a/package.json
+++ b/package.json
@@ -20,10 +20,7 @@
     "js-beautify": "^1.5.5",
     "wcwidth": "*"
   },
-  "devDependencies": {
-    "expresso": "~0.9",
-    "should": "~0.6"
-  },
+  
   "main": "lib",
   "files": [
     "lib"


### PR DESCRIPTION
## The problem

Currently when table's width is above terminal width, all column widths will be recalculated and the final result is equal column widths. This leads to unwanted behavior for our use-case. for example:

| General | Usage |
| --- | --- |
| Android | some very long command with options and several other items |

In this case after wrapping the text, both columns will have the same width, which will lead to output, which will not look very good.
### Proposed solution

Use each column's required width and calculate its relative size based on current terminal width. For example if we have the following structure and columns width:

| Column A | Column B | Column C |
| --- | --- | --- |
| 30 | 50 | 20 |

and the available terminal width is 80, the calculation of the columns should be:
Column A = (30 / 100) \* 80 = 24
Column B = (50 / 100) \* 80 = 40
Column C = (20 / 100) \* 80  = 16
Column A + Column B + Column C = 80
### Extended solution

In most of our use-cases, we have 2 columns in our table - the first one contains short text (around 10 symbols) and the second column has some very long text. After applying suggested solution, first column's width is reduced and the text inside it is trimmed or placed on two rows. Add min_column_width property and if the width of the column is below this value, do not reduce columns size. In case the calculated value is below min_column_width, return min_column_width. The problem here is in the following scenario:

| Column A | Column B | Column C | Column D | Column E |
| --- | --- | --- | --- | --- |
| 10 | 20 | 30 | 10 | 30 |

The sum is 100. Max terminal width is 80.
Lets set the min_column_width property to 23. Here's the calculation:
Column A - 10 < 23 => 10
Column B - (20 / 100) \* 80 = 16
Column C - (30 / 100) \* 80 = 24
Column D - 10 < 23 => 10
Column E - (30 / 100) \* 80 = 24
A + B + C +D +E = 74
But some of the columns are less then already defined min_column_width(23). If we set them to min_column_width the values are:
Column A - 10 < 23 => 10
Column B - (20 / 100) \* 80 = 16 < 23 => 23
Column C - (30 / 100) \* 80 = 24
Column D - 10 < 23 => 10
Column E - (30 / 100) \* 80 = 24
A + B + C +D +E = 91

This way we've exceeded terminal width. The proposed solution is to modify the formula based on the remaining terminal and the remaining required size.
For each column we check if its size is below min_column_width. In case it is, we set this column as static (its size will not change) and we remove the width
from remaining terminal and remaining required width. If the width is above min_column_width we execute:
(required_col_width / remaining_required_size) \* remaining_terminal_width
In case the value is above min_column_width, we save it as dynamic size (could be changed later).
In case the value is below min_column_width, we save it as static size and remove it from remaining_terminal_width. The original value should be removed from remaining_required_size.
At this point we have to recalculate all dynamic values and apply the same logic as above.
## Implement own line splitting
### js-beautify issues

Remove usage of `js-beautify` module for spliting the string for multiline usage. There are two problems with `js-beautify` module:
- text that contains <...> is always split on several lines. `js-beautify` considers <...> as HTML tag and places is to new line.
- `js-beautify` does not guarantee that the string will be split based on wrap_line_length value. The string is split based on the first delimiter AFTER wrap_line_length.
### Proposed solution

Use own function instead of `js-beautify` to split the lines. The following rules are applied:
- if content is below wrap_line_length, return the content without modifying it
- if content is above wrap_line_length the rules are:
  - if the symbol on index "wrap_line_length" is delimiter, take all symbols up to it and split the rest of the text based on this rules (call the method with rest of the text)
  - if the next symbol is not delimiter, try to find the last delimiter in the symbols up to wrap_line_length index.
    - in case delimiter is found, split the line by it and split everything after it based on the same rules
    - in case delimiter is not found, split the word, this means - take all symbols up to wrap_line_length and split the rest of the string based on the same rules.
### 'Code' problem

If the passed text is colorized, the string contains several specific colorization symbols. They are rendered by the console as colors, but when checking string.length, they are calculated (typically the length of these symbols is 8-9). After we split the content on several lines, we lose the colorization of subsequent lines.
### 'Code' problem solution

When splitting the text, calculate the length of all "code" symbols which we can include until we reach the allowed length of the column. When splitting, check the number of "code" segments in the line - if they are odd number, get the last "code" segment and add it to the beginning of the remaining text. This way we have the correct colorization on the next lines.
